### PR TITLE
Reconsider inclusion of opid in mongodb_currentop_query_uptime

### DIFF
--- a/exporter/currentop_collector.go
+++ b/exporter/currentop_collector.go
@@ -18,6 +18,7 @@ package exporter
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,23 +29,25 @@ import (
 )
 
 type currentopCollector struct {
-	ctx            context.Context
-	base           *baseCollector
-	compatibleMode bool
-	topologyInfo   labelsGetter
+	ctx               context.Context
+	base              *baseCollector
+	compatibleMode    bool
+	topologyInfo      labelsGetter
+	currentopslowtime string
 }
 
 var ErrInvalidOrMissingInprogEntry = errors.New("invalid or missing inprog entry in currentop results")
 
 // newCurrentopCollector creates a collector for being processed queries.
 func newCurrentopCollector(ctx context.Context, client *mongo.Client, logger *logrus.Logger,
-	compatible bool, topology labelsGetter,
+	compatible bool, topology labelsGetter, currentOpSlowTime string,
 ) *currentopCollector {
 	return &currentopCollector{
-		ctx:            ctx,
-		base:           newBaseCollector(client, logger),
-		compatibleMode: compatible,
-		topologyInfo:   topology,
+		ctx:               ctx,
+		base:              newBaseCollector(client, logger),
+		compatibleMode:    compatible,
+		topologyInfo:      topology,
+		currentopslowtime: currentOpSlowTime,
 	}
 }
 
@@ -61,6 +64,12 @@ func (d *currentopCollector) collect(ch chan<- prometheus.Metric) {
 
 	logger := d.base.logger
 	client := d.base.client
+	slowtime, err := time.ParseDuration(d.currentopslowtime)
+	if err != nil {
+		ch <- prometheus.NewInvalidMetric(prometheus.NewInvalidDesc(err), err)
+		return
+	}
+	slowtimems := slowtime.Microseconds()
 
 	// Get all requests that are being processed except system requests (admin and local).
 	cmd := bson.D{
@@ -68,6 +77,7 @@ func (d *currentopCollector) collect(ch chan<- prometheus.Metric) {
 		{Key: "active", Value: true},
 		{Key: "microsecs_running", Value: bson.D{
 			{Key: "$exists", Value: true},
+			{Key: "$gte", Value: slowtimems},
 		}},
 		{Key: "op", Value: bson.D{{Key: "$ne", Value: ""}}},
 		{Key: "ns", Value: bson.D{

--- a/exporter/currentop_collector_test.go
+++ b/exporter/currentop_collector_test.go
@@ -60,8 +60,9 @@ func TestCurrentopCollector(t *testing.T) {
 	}()
 
 	ti := labelsGetterMock{}
+	st := "0s"
 
-	c := newCurrentopCollector(ctx, client, logrus.New(), false, ti)
+	c := newCurrentopCollector(ctx, client, logrus.New(), false, ti, st)
 
 	// Filter metrics by reason:
 	// 1. The result will be different on different hardware

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -57,6 +57,7 @@ type Opts struct {
 	GlobalConnPool         bool
 	ProfileTimeTS          int
 	TimeoutOffset          int
+	CurrentOpSlowTime      string
 
 	CollectAll               bool
 	EnableDBStats            bool
@@ -203,9 +204,9 @@ func (e *Exporter) makeRegistry(ctx context.Context, client *mongo.Client, topol
 		registry.MustRegister(cc)
 	}
 
-	if e.opts.EnableCurrentopMetrics && nodeType != typeMongos && limitsOk && requestOpts.EnableCurrentopMetrics {
+	if e.opts.EnableCurrentopMetrics && nodeType != typeMongos && limitsOk && requestOpts.EnableCurrentopMetrics && e.opts.CurrentOpSlowTime != "" {
 		coc := newCurrentopCollector(ctx, client, e.opts.Logger,
-			e.opts.CompatibleMode, topologyInfo)
+			e.opts.CompatibleMode, topologyInfo, e.opts.CurrentOpSlowTime)
 		registry.MustRegister(coc)
 	}
 

--- a/main.go
+++ b/main.go
@@ -68,6 +68,8 @@ type GlobalFlags struct {
 
 	ProfileTimeTS int `name:"collector.profile-time-ts" help:"Set time for scrape slow queries." default:"30"`
 
+	CurrentOpSlowTime string `name:"collector.currentopmetrics-slow-time" help:"Set minimum time for registration queries." default:"1m"`
+
 	DiscoveringMode bool `name:"discovering-mode" help:"Enable autodiscover collections" negatable:""`
 	CompatibleMode  bool `name:"compatible-mode" help:"Enable old mongodb-exporter compatible metrics" negatable:""`
 	Version         bool `name:"version" help:"Show version and exit"`
@@ -158,9 +160,10 @@ func buildExporter(opts GlobalFlags, uri string, log *logrus.Logger) *exporter.E
 
 		EnableOverrideDescendingIndex: opts.EnableOverrideDescendingIndex,
 
-		CollStatsLimit: opts.CollStatsLimit,
-		CollectAll:     opts.CollectAll,
-		ProfileTimeTS:  opts.ProfileTimeTS,
+		CollStatsLimit:    opts.CollStatsLimit,
+		CollectAll:        opts.CollectAll,
+		ProfileTimeTS:     opts.ProfileTimeTS,
+		CurrentOpSlowTime: opts.CurrentOpSlowTime,
 	}
 
 	e := exporter.New(exporterOpts)


### PR DESCRIPTION
Issues: [#746](https://github.com/percona/mongodb_exporter/issues/746)

This bug fix limits the value of the metric received from CurrentOP() to the specified value.
This should relieve the Prometheus database of junk values.